### PR TITLE
fix: Mouse movement does not Stop Break and does not postpone Break Starting

### DIFF
--- a/TrackYourDay.sln
+++ b/TrackYourDay.sln
@@ -33,7 +33,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {67D615D5-394B-4346-A26E-558AF9E3E0D1}
 		        SolutionGuid = {61F7FB11-1E47-470C-91E2-47F8143E1572}
+		SolutionGuid = {67D615D5-394B-4346-A26E-558AF9E3E0D1}
 	EndGlobalSection
 EndGlobal

--- a/src/TrackYourDay.Core/Activities/ActivityFactory.cs
+++ b/src/TrackYourDay.Core/Activities/ActivityFactory.cs
@@ -32,7 +32,7 @@ namespace TrackYourDay.Core.Activities
 
         public static InstantActivity MouseMovedActivity(DateTime occuranceDate, SystemState systemState)
         {
-            return new InstantActivity(occuranceDate, systemState);
+            return new InstantActivity(Guid.NewGuid(), occuranceDate, systemState);
         }
     }
 }

--- a/src/TrackYourDay.Core/Activities/InstantActivity.cs
+++ b/src/TrackYourDay.Core/Activities/InstantActivity.cs
@@ -1,7 +1,7 @@
 ﻿using TrackYourDay.Core.Activities.SystemStates;
 namespace TrackYourDay.Core.Activities
 {
-    public record class InstantActivity(DateTime OccuranceDate, SystemState SystemState)
+    public record class InstantActivity(Guid Guid, DateTime OccuranceDate, SystemState SystemState)
     {
         public TimeSpan GetDuration()
         {

--- a/src/TrackYourDay.MAUI/BackgroundJobs/ActivityStartedNotificationHandler.cs
+++ b/src/TrackYourDay.MAUI/BackgroundJobs/ActivityStartedNotificationHandler.cs
@@ -19,7 +19,6 @@ namespace TrackYourDay.MAUI.BackgroundJobs
         public Task Handle(PeriodicActivityStartedNotification notification, CancellationToken cancellationToken)
         {
             this.breakTracker.AddActivityToProcess(notification.StartedActivity.StartDate, notification.StartedActivity.SystemState, notification.StartedActivity.Guid);
-
             return Task.CompletedTask;
         }
     }

--- a/src/TrackYourDay.MAUI/BackgroundJobs/InstantActivityOccuredNotificationHandler.cs
+++ b/src/TrackYourDay.MAUI/BackgroundJobs/InstantActivityOccuredNotificationHandler.cs
@@ -1,0 +1,25 @@
+﻿using MediatR;
+using TrackYourDay.Core.Activities.Notifications;
+using TrackYourDay.Core.Breaks;
+
+namespace TrackYourDay.MAUI.BackgroundJobs
+{
+    internal class InstantActivityOccuredNotificationHandler : INotificationHandler<InstantActivityOccuredNotification>
+    {
+        private readonly BreakTracker breakTracker;
+
+        public InstantActivityOccuredNotificationHandler(BreakTracker breakTracker)
+        {
+            this.breakTracker = breakTracker;
+        }
+
+        public Task Handle(InstantActivityOccuredNotification notification, CancellationToken cancellationToken)
+        {
+            this.breakTracker.AddActivityToProcess(
+                notification.InstantActivity.OccuranceDate, 
+                notification.InstantActivity.SystemState, 
+                notification.InstantActivity.Guid);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Closes #37 

Instant Activity Notification (Mouse movement) was not handled in Application